### PR TITLE
do not install any packages by default.  Fix comment

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -63,6 +63,7 @@ compile_python() {
   make install
   wget -q https://bootstrap.pypa.io/get-pip.py
   /opt/python/${VERSION}/bin/python${PYTHON_MAJOR} get-pip.py
+  /opt/python/${VERSION}/bin/pip install ipykernel
 }
 
 set_up_environment() {


### PR DESCRIPTION
Remove all the default installed packages, since users cannot use them!

Make sure to leave ipykernel so we can register the kernels