### PR TITLE
Allow different instance types

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -131,8 +131,50 @@ pythonBuildsBatchComputeEnvironment:
       InstanceRole:
         "Fn::GetAtt": [ pythonBuildsIamInstanceProfile, Arn ]
       InstanceTypes:
-        - m5
-        - r5
+        - m6i.xlarge
+        - m6i.2xlarge
+        - m6i.4xlarge
+        - m6i.8xlarge
+        - m5.xlarge
+        - m5.2xlarge
+        - m5.4xlarge
+        - m5.8xlarge
+        - m5a.xlarge
+        - m5a.2xlarge
+        - m5a.4xlarge
+        - m5a.8xlarge
+        - m4.xlarge
+        - m4.2xlarge
+        - m4.4xlarge
+        - m4.8xlarge
+        - r5.xlarge
+        - r5.2xlarge
+        - r5.4xlarge
+        - r5.8xlarge
+        - r5a.xlarge
+        - r5a.2xlarge
+        - r5a.4xlarge
+        - r5a.8xlarge
+        - r4.xlarge
+        - r4.2xlarge
+        - r4.4xlarge
+        - r4.8xlarge
+        - c6i.xlarge
+        - c6i.2xlarge
+        - c6i.4xlarge
+        - c6i.8xlarge
+        - c5.xlarge
+        - c5.2xlarge
+        - c5.4xlarge
+        - c5.8xlarge
+        - c5a.xlarge
+        - c5a.2xlarge
+        - c5a.4xlarge
+        - c5a.8xlarge
+        - c4.xlarge
+        - c4.2xlarge
+        - c4.4xlarge
+        - c4.8xlarge
       Ec2KeyPair: ${self:custom.ec2KeyPair}
       Tags: ${self:provider.stackTags}
       MinvCpus: 0


### PR DESCRIPTION
It doesn't have to be giant m5.24xlarges.  In fact, we don't really care if it's a bunch of small ones, so lets prioritize them. Just like we did in revdepcheck-cloud