### PR TITLE
enable optimizations

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -58,6 +58,7 @@ compile_python() {
   ./configure \
     --prefix=/opt/python/${VERSION} \
     --enable-shared \
+    --enable-optimizations \
     --enable-ipv6 \
     LDFLAGS=-Wl,-rpath=/opt/python/${VERSION}/lib,--disable-new-dtags
 


### PR DESCRIPTION
enabling optimizations substantially increases the time required to compile these builds but the resulting executable should run a lot faster

closes #39