### PR TITLE
Switch to using vpcId and creating the security group directly from within serverless

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -1,3 +1,11 @@
+pythonBuildsSecurityGroup:
+  Type: AWS::EC2::SecurityGroup
+  Properties:
+    GroupDescription: Security Group for the PythonBuilds jobs
+    GroupName: PythonBuildsJobs
+    VpcId: ${self:custom.vpcId}
+    Tags: ${self:custom.tagsList}
+
 # s3 bucket
 S3Bucket:
   Type: AWS::S3::Bucket
@@ -128,7 +136,8 @@ pythonBuildsBatchComputeEnvironment:
           Ref: pythonBuildsEcsLaunchTemplate
       SpotIamFleetRole:
         "Fn::GetAtt": [ pythonBuildsSpotFleetIamRole, Arn ]
-      SecurityGroupIds: ${self:custom.securityGroupIds}
+      SecurityGroupIds:
+        "Fn::GetAtt": [ pythonBuildsSecurityGroup, GroupId ]
       Subnets: ${self:custom.subnets}
       Type: SPOT
       BidPercentage: 100


### PR DESCRIPTION
Requires updates to the `serverless-custom.yml` file be uploaded to s3 first

closes #63 