### PR TITLE
Some tags are a list, some tags are a map.  CF is annoying

### DIFF
--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -4,7 +4,7 @@ pythonBuildsSecurityGroup:
     GroupDescription: Security Group for the PythonBuilds jobs
     GroupName: PythonBuildsJobs
     VpcId: ${self:custom.vpcId}
-    Tags: ${self:provider.stackTags}
+    Tags: ${self:provider.tagsList}
 
 # s3 bucket
 S3Bucket:
@@ -154,7 +154,7 @@ pythonBuildsBatchComputeEnvironment:
         - c5
         - c5a
       Ec2KeyPair: ${self:custom.ec2KeyPair}
-      Tags: ${self:provider.stackTags}
+      Tags: ${self:provider.tagsMap}
       MinvCpus: 0
       DesiredvCpus: 0
       MaxvCpus: 1024

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,7 +21,17 @@ provider:
   stage: ${opt:stage, self:custom.defaultStage}
   deploymentBucket:
     name: ${self:custom.deploymentBucket}
-  stackTags: ${self:custom.${self:provider.stage}.stackTags}
+  tagsList:
+    - Key: rs:project
+      Value: ${self:custom.${self:provider.stage}.tags.project}
+    - Key: rs:owner
+      Value: ${self:custom.${self:provider.stage}.tags.owner}
+    - Key: rs:environment
+      Value: ${self:custom.${self:provider.stage}.tags.environment}
+  tagsMap:
+    "rs:owner": ${self:custom.${self:provider.stage}.tags.owner}
+    "rs:project": ${self:custom.${self:provider.stage}.tags.project}
+    "rs:environment": ${self:custom.${self:provider.stage}.tags.environment}
   iamRoleStatements:
     -  Effect: Allow
        Action:


### PR DESCRIPTION
Because of this, the structure of `serverless-custom.yml` is changing, no longer `stackTags` just `tags` as a dict with easy to use keys to generate the `tagsList` and `tagsMap` that we need for the different pieces

PS: I've already updated `serverless-custom.yml` so I'm going to push this out to staging