### PR TITLE
Centos 7 builds for more recent python versions

### DIFF
--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -4,9 +4,11 @@ ENV OS_IDENTIFIER=centos-7
 
 # RUN sed -i 's/^enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo && yum -y update
 
-RUN yum -y install epel-release
+RUN yum -y install epel-release \
+	centos-release-scl
 
 RUN yum -y install \
+  devtoolset-11 \
   autoconf \
   bluez-libs-devel \
   bzip2 \
@@ -53,4 +55,4 @@ RUN chmod 0777 /opt
 
 COPY package.centos-7 /package.sh
 COPY build.sh .
-ENTRYPOINT ./build.sh
+ENTRYPOINT ./build.sh 

--- a/builder/Dockerfile.centos-7
+++ b/builder/Dockerfile.centos-7
@@ -4,6 +4,8 @@ ENV OS_IDENTIFIER=centos-7
 
 # RUN sed -i 's/^enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo && yum -y update
 
+RUN yum -y install epel-release
+
 RUN yum -y install \
   autoconf \
   bluez-libs-devel \
@@ -22,7 +24,7 @@ RUN yum -y install \
   libffi-devel \
   mesa-libGL-devel \
   ncurses-devel \
-  openssl-devel \
+  openssl11-devel \
   readline-devel \
   sqlite-devel \
   systemtap-sdt-devel \

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 export S3_BUCKET_PREFIX=${S3_BUCKET_PREFIX-""}
 export OS_IDENTIFIER=${OS_IDENTIFIER-"unknown"}
@@ -37,7 +37,8 @@ upload_python() {
 
 # archive_python() - $1 as python version, $2 as target filename
 archive_python() {
-  tar czf /tmp/${2} --directory=/opt/python ${1} --owner=0 --group=0
+        ls -l /opt/python 
+	tar czf /tmp/${2} --directory=/opt/python ${1} --owner=0 --group=0
 }
 
 # fetch_python_source() - $1 as python version
@@ -55,22 +56,25 @@ compile_python() {
   local PYTHON_MAJOR=$(cut -d'.' -f1 <<<$1)
 
   cd /tmp/Python-${VERSION}
+  local cmdprefix="bash -c "
   # special fix for CentOS/RHEL7 to use openssl11
-  . /etc/os-release
-  if [[ $ID$VERSION_ID == "centos7" ]]; then 
+  linuxdistro=`. /etc/os-release && echo $ID$VERSION_ID`
+  if [[ $linuxdistro == "centos7" ]]; then 
     sed -i 's/PKG_CONFIG openssl /PKG_CONFIG openssl11 /g' configure
+    cmdprefix="scl enable devtoolset-11 "
   fi
-
-  ./configure \
+ 
+  $cmdprefix "echo ${VERSION}" 
+  $cmdprefix "./configure \
     --prefix=/opt/python/${VERSION} \
     --enable-shared \
     --enable-optimizations \
     --enable-ipv6 \
-    LDFLAGS=-Wl,-rpath=/opt/python/${VERSION}/lib,--disable-new-dtags
+    LDFLAGS=-Wl,-rpath=/opt/python/${VERSION}/lib,--disable-new-dtags"
 
   make clean
-  make  
-  make install
+  $cmdprefix 'make'  
+  $cmdprefix 'make install'
 }
 
 package_python() {

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -55,6 +55,12 @@ compile_python() {
   local PYTHON_MAJOR=$(cut -d'.' -f1 <<<$1)
 
   cd /tmp/Python-${VERSION}
+  # special fix for CentOS/RHEL7 to use openssl11
+  . /etc/os-release
+  if [[ $ID$VERSION_ID == "centos7" ]]; then 
+    sed -i 's/PKG_CONFIG openssl /PKG_CONFIG openssl11 /g' configure
+  fi
+
   ./configure \
     --prefix=/opt/python/${VERSION} \
     --enable-shared \
@@ -63,7 +69,7 @@ compile_python() {
     LDFLAGS=-Wl,-rpath=/opt/python/${VERSION}/lib,--disable-new-dtags
 
   make clean
-  make
+  make  
   make install
 }
 

--- a/builder/package.centos-7
+++ b/builder/package.centos-7
@@ -19,6 +19,7 @@ homepage: https://www.python.org/
 license: 	GPL-3.0-only
 depends:
 - libev-devel
+- openssl11-devel
 contents:
 - src: /opt/python/${PYTHON_VERSION}
   dst: /opt/python/${PYTHON_VERSION}


### PR DESCRIPTION
This PR is offering the possibility to build more recent Python versions under CentOS 7 due to 

- usage of `openssl11`
- usage of `devtoolset-11` to enable more recent versions of compilers

I have successfully built the latest available versions of the 3.9, 3.10 and 3.11 branch under CentOS 7 and also successfully installed. 

