### PR TITLE
Fix unattended installs for rhel based distros

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-THIS_VERSION="1.1.0"
+THIS_VERSION="1.1.1"
 
 # Call with:
 #   bash -c "$(curl -L https://rstd.io/python-install)"

--- a/install.sh
+++ b/install.sh
@@ -325,7 +325,7 @@ install_pre () {
 
   case $os in
     "RedHat" | "CentOS" | "Alma" | "Rocky")
-      install_epel "${ver}"
+      install_epel "${os}" "${ver}"
       ;;
     "Amazon")
       install_epel_amzn


### PR DESCRIPTION
Unattended installations for rhel based distros (RedHat, CentOS, Alma and Rocky) were failing due to the `os` name variable being replaced by the version, thus getting to `case $os in` wasn't finding any case for it to continue the installation.