### PR TITLE
Fix the serverless deploy for python-builds by implementing changes from r-builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "description": "",
   "version": "0.1.0",
   "devDependencies": {
-    "serverless": "^3.30.1",
-    "serverless-python-requirements": "^5.4.0",
-    "serverless-step-functions": "^3.13.1",
-    "serverless-pseudo-parameters": "^2.2.0"
+    "serverless": "^3.36.0",
+    "serverless-python-requirements": "^6.0.0",
+    "serverless-step-functions": "^3.21.0",
+    "serverless-better-credentials": "^2.0.0"
   }
 }

--- a/serverless-resources.yml
+++ b/serverless-resources.yml
@@ -165,7 +165,7 @@ pythonBuildsBatchJobDefinitionUbuntu2004:
       Memory: 4096
       JobRoleArn:
         "Fn::GetAtt": [ pythonBuildsEcsTaskIamRole, Arn ]
-      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/python-builds:ubuntu-2004"
+      Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/python-builds:ubuntu-2004"
     Timeout:
       AttemptDurationSeconds: 7200
 pythonBuildsBatchJobDefinitionUbuntu2204:
@@ -179,7 +179,7 @@ pythonBuildsBatchJobDefinitionUbuntu2204:
       Memory: 4096
       JobRoleArn:
         "Fn::GetAtt": [ pythonBuildsEcsTaskIamRole, Arn ]
-      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/python-builds:ubuntu-2204"
+      Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/python-builds:ubuntu-2204"
     Timeout:
       AttemptDurationSeconds: 7200
 pythonBuildsBatchJobDefinitionUbuntu2404:
@@ -193,7 +193,7 @@ pythonBuildsBatchJobDefinitionUbuntu2404:
       Memory: 4096
       JobRoleArn:
         "Fn::GetAtt": [ pythonBuildsEcsTaskIamRole, Arn ]
-      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/python-builds:ubuntu-2404"
+      Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/python-builds:ubuntu-2404"
     Timeout:
       AttemptDurationSeconds: 7200
 pythonBuildsBatchJobDefinitionDebian11:
@@ -207,7 +207,7 @@ pythonBuildsBatchJobDefinitionDebian11:
       Memory: 4096
       JobRoleArn:
         "Fn::GetAtt": [ pythonBuildsEcsTaskIamRole, Arn ]
-      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/python-builds:debian-11"
+      Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/python-builds:debian-11"
     Timeout:
       AttemptDurationSeconds: 7200
 pythonBuildsBatchJobDefinitionDebian12:
@@ -221,7 +221,7 @@ pythonBuildsBatchJobDefinitionDebian12:
       Memory: 4096
       JobRoleArn:
         "Fn::GetAtt": [ pythonBuildsEcsTaskIamRole, Arn ]
-      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/python-builds:debian-12"
+      Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/python-builds:debian-12"
     Timeout:
       AttemptDurationSeconds: 7200
 pythonBuildsBatchJobDefinitionCentos7:
@@ -235,7 +235,7 @@ pythonBuildsBatchJobDefinitionCentos7:
       Memory: 4096
       JobRoleArn:
         "Fn::GetAtt": [ pythonBuildsEcsTaskIamRole, Arn ]
-      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/python-builds:centos-7"
+      Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/python-builds:centos-7"
     Timeout:
       AttemptDurationSeconds: 7200
 pythonBuildsBatchJobDefinitionCentos8:
@@ -249,7 +249,7 @@ pythonBuildsBatchJobDefinitionCentos8:
       Memory: 4096
       JobRoleArn:
         "Fn::GetAtt": [ pythonBuildsEcsTaskIamRole, Arn ]
-      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/python-builds:centos-8"
+      Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/python-builds:centos-8"
     Timeout:
       AttemptDurationSeconds: 7200
 pythonBuildsBatchJobDefinitionRhel9:
@@ -263,7 +263,7 @@ pythonBuildsBatchJobDefinitionRhel9:
       Memory: 4096
       JobRoleArn:
         "Fn::GetAtt": [ pythonBuildsEcsTaskIamRole, Arn ]
-      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/python-builds:rhel-9"
+      Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/python-builds:rhel-9"
     Timeout:
       AttemptDurationSeconds: 7200
 
@@ -278,7 +278,7 @@ pythonBuildsBatchJobDefinitionOpensuse155:
       Memory: 4096
       JobRoleArn:
         "Fn::GetAtt": [ pythonBuildsEcsTaskIamRole, Arn ]
-      Image: "#{AWS::AccountId}.dkr.ecr.#{AWS::Region}.amazonaws.com/python-builds:opensuse-155"
+      Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/python-builds:opensuse-155"
     Timeout:
       AttemptDurationSeconds: 7200
 

--- a/serverless-stepf.yml
+++ b/serverless-stepf.yml
@@ -6,7 +6,8 @@ pythonBuilds:
     States:
       QueueBuilds:
         Type: Task
-        Resource: arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${self:provider.stage}-queueBuilds
+        Resource:
+          Fn::Sub: arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${self:provider.stage}-queueBuilds
         Next: Wait
       Wait:
         Type: Wait
@@ -14,7 +15,8 @@ pythonBuilds:
         Next: JobQueueStatus
       JobQueueStatus:
         Type: Task
-        Resource: arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${self:provider.stage}-jobQueueStatus
+        Resource:
+          Fn::Sub: arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${self:provider.stage}-jobQueueStatus
         Next: QueueEmpty?
       QueueEmpty?:
         Type: Choice
@@ -27,7 +29,8 @@ pythonBuilds:
             Next: Finished
       Finished:
         Type: Task
-        Resource: arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${self:provider.stage}-finished
+        Resource:
+          Fn::Sub: arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${self:provider.stage}-finished
         Next: SuccessOrFail
       SuccessOrFail:
         Type: Choice

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,7 +3,7 @@ service: python-builds
 plugins:
   - serverless-python-requirements
   - serverless-step-functions
-  - serverless-pseudo-parameters
+  - serverless-better-credentials
 custom: ${file(./serverless-custom.yml)}
 
 package:


### PR DESCRIPTION
the 4 PRs I needed to fix r-builds are: 

https://github.com/rstudio/r-builds/pull/222
https://github.com/rstudio/r-builds/pull/223
https://github.com/rstudio/r-builds/pull/224
https://github.com/rstudio/r-builds/pull/225

I've copied those same changes over here